### PR TITLE
Update client auth token function params

### DIFF
--- a/src/tests/server_tests.py
+++ b/src/tests/server_tests.py
@@ -40,10 +40,10 @@ class TestStringMethods(unittest.TestCase):
 
     def test_client_auth_token(self):
         user_id = '1'
-        organization_id = '1'
+        group_id = '1'
         email = 'dummy@cord.com'
         name = 'Mr. Dummy'
-        org_name = "Cord"
+        group_name = "Cord"
         short_name = 'dumdum'
         status = 'active'
         profile_picture_url = 'https://www.someurl.com'
@@ -54,7 +54,7 @@ class TestStringMethods(unittest.TestCase):
             dummy_app_secret,
             {
                 "user_id": user_id,
-                "organization_id": organization_id,
+                "group_id": group_id,
                 "user_details": {
                     "email": email,
                     "name": name,
@@ -63,14 +63,14 @@ class TestStringMethods(unittest.TestCase):
                     "profilePictureURL": profile_picture_url,
                     "metadata": metadata
                 },
-                "organization_details": {
-                    "name": org_name,
+                "group_details": {
+                    "name": group_name,
                     "status": status,
                     "members": [user_id]
                 }
             })
 
-        correct_token = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiIxMjM0NTY3ODkiLCJleHAiOjE2OTYzMzAyNjgsImlhdCI6MTY5NjMzMDIwOCwidXNlcl9pZCI6IjEiLCJvcmdhbml6YXRpb25faWQiOiIxIiwidXNlcl9kZXRhaWxzIjp7ImVtYWlsIjoiZHVtbXlAY29yZC5jb20iLCJuYW1lIjoiTXIuIER1bW15Iiwic2hvcnROYW1lIjoiZHVtZHVtIiwic3RhdHVzIjoiYWN0aXZlIiwicHJvZmlsZVBpY3R1cmVVUkwiOiJodHRwczovL3d3dy5zb21ldXJsLmNvbSIsIm1ldGFkYXRhIjp7InJhbmRvbSI6ImhlbGxvIn19LCJvcmdhbml6YXRpb25fZGV0YWlscyI6eyJuYW1lIjoiQ29yZCIsInN0YXR1cyI6ImFjdGl2ZSIsIm1lbWJlcnMiOlsiMSJdfX0.QVDL1FS_mhZipUDcXJuammRF694rmV6kg0C-mZZIVTeRN9LLxo18-04McpwAW7iLYsgAC98N8uNix8OneB01Yw'
+        correct_token = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiIxMjM0NTY3ODkiLCJleHAiOjE3MDU0ODcxNzUsImlhdCI6MTcwNTQ4NzExNSwidXNlcl9pZCI6IjEiLCJncm91cF9pZCI6IjEiLCJ1c2VyX2RldGFpbHMiOnsiZW1haWwiOiJkdW1teUBjb3JkLmNvbSIsIm5hbWUiOiJNci4gRHVtbXkiLCJzaG9ydE5hbWUiOiJkdW1kdW0iLCJzdGF0dXMiOiJhY3RpdmUiLCJwcm9maWxlUGljdHVyZVVSTCI6Imh0dHBzOi8vd3d3LnNvbWV1cmwuY29tIiwibWV0YWRhdGEiOnsicmFuZG9tIjoiaGVsbG8ifX0sImdyb3VwX2RldGFpbHMiOnsibmFtZSI6IkNvcmQiLCJzdGF0dXMiOiJhY3RpdmUiLCJtZW1iZXJzIjpbIjEiXX19.3CHm9fxtW1b5XQ2pVNgRl2a7ePI9ffIgaVd2Ck8Vtq9s4OZHDbvvnwr_TkKWcZpokIBmguOOzA5CniexzIiaVw'
 
         self.assertEqual(token, correct_token)
         encoded_payload = token.split('.')[1]

--- a/src/tests/server_tests.py
+++ b/src/tests/server_tests.py
@@ -71,6 +71,60 @@ class TestStringMethods(unittest.TestCase):
             })
 
         correct_token = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiIxMjM0NTY3ODkiLCJleHAiOjE3MDU0ODcxNzUsImlhdCI6MTcwNTQ4NzExNSwidXNlcl9pZCI6IjEiLCJncm91cF9pZCI6IjEiLCJ1c2VyX2RldGFpbHMiOnsiZW1haWwiOiJkdW1teUBjb3JkLmNvbSIsIm5hbWUiOiJNci4gRHVtbXkiLCJzaG9ydE5hbWUiOiJkdW1kdW0iLCJzdGF0dXMiOiJhY3RpdmUiLCJwcm9maWxlUGljdHVyZVVSTCI6Imh0dHBzOi8vd3d3LnNvbWV1cmwuY29tIiwibWV0YWRhdGEiOnsicmFuZG9tIjoiaGVsbG8ifX0sImdyb3VwX2RldGFpbHMiOnsibmFtZSI6IkNvcmQiLCJzdGF0dXMiOiJhY3RpdmUiLCJtZW1iZXJzIjpbIjEiXX19.3CHm9fxtW1b5XQ2pVNgRl2a7ePI9ffIgaVd2Ck8Vtq9s4OZHDbvvnwr_TkKWcZpokIBmguOOzA5CniexzIiaVw'
+        
+        self.assertEqual(token, correct_token)
+        encoded_payload = token.split('.')[1]
+        decoded_payload = base64.b64decode(
+            encoded_payload + '=')  # Need to pad the b64 payload
+        payload = json.loads(
+            decoded_payload.decode('utf8').replace("'", '"'))
+        self.assertEqual(dummy_app_id, payload["app_id"])
+        self.assertEqual(user_id, payload["user_id"])
+        self.assertEqual(group_id, payload["group_id"])
+        self.assertEqual(email, payload["user_details"]['email'])
+        self.assertEqual(name, payload["user_details"]['name'])
+        self.assertEqual(short_name, payload["user_details"]['shortName'])
+        self.assertEqual(status, payload["user_details"]['status'])
+        self.assertEqual(profile_picture_url,
+                         payload["user_details"]['profilePictureURL'])
+        self.assertEqual(metadata, payload["user_details"]['metadata'])
+        self.assertEqual(group_name, payload["group_details"]['name'])
+        self.assertEqual(status, payload["group_details"]['status'])
+        self.assertEqual([user_id], payload["group_details"]['members'])
+
+    def test_client_auth_token_with_deprecated_params(self):
+        user_id = '1'
+        organization_id = '1'
+        email = 'dummy@cord.com'
+        name = 'Mr. Dummy'
+        org_name = "Cord"
+        short_name = 'dumdum'
+        status = 'active'
+        profile_picture_url = 'https://www.someurl.com'
+        metadata = {"random": "hello"}
+
+        token = get_client_auth_token(
+            dummy_app_id,
+            dummy_app_secret,
+            {
+                "user_id": user_id,
+                "organization_id": organization_id,
+                "user_details": {
+                    "email": email,
+                    "name": name,
+                    "shortName": short_name,
+                    "status": status,
+                    "profilePictureURL": profile_picture_url,
+                    "metadata": metadata
+                },
+                "organization_details": {
+                    "name": org_name,
+                    "status": status,
+                    "members": [user_id]
+                }
+            })
+
+        correct_token = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiIxMjM0NTY3ODkiLCJleHAiOjE2OTYzMzAyNjgsImlhdCI6MTY5NjMzMDIwOCwidXNlcl9pZCI6IjEiLCJvcmdhbml6YXRpb25faWQiOiIxIiwidXNlcl9kZXRhaWxzIjp7ImVtYWlsIjoiZHVtbXlAY29yZC5jb20iLCJuYW1lIjoiTXIuIER1bW15Iiwic2hvcnROYW1lIjoiZHVtZHVtIiwic3RhdHVzIjoiYWN0aXZlIiwicHJvZmlsZVBpY3R1cmVVUkwiOiJodHRwczovL3d3dy5zb21ldXJsLmNvbSIsIm1ldGFkYXRhIjp7InJhbmRvbSI6ImhlbGxvIn19LCJvcmdhbml6YXRpb25fZGV0YWlscyI6eyJuYW1lIjoiQ29yZCIsInN0YXR1cyI6ImFjdGl2ZSIsIm1lbWJlcnMiOlsiMSJdfX0.QVDL1FS_mhZipUDcXJuammRF694rmV6kg0C-mZZIVTeRN9LLxo18-04McpwAW7iLYsgAC98N8uNix8OneB01Yw'
 
         self.assertEqual(token, correct_token)
         encoded_payload = token.split('.')[1]

--- a/src/types/types.py
+++ b/src/types/types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import json
+import warnings
 
 
 class Status(Enum):
@@ -19,6 +20,17 @@ class PlatformUserVariables:
 
 
 class PlatformOrganizationVariables:
+    """
+        Deprecated - please use PlatformGroupVariables instead
+    """
+    def __init__(self, id: str, name: str, status: Status = None, members: list[str] = None):
+        self.id = id
+        self.name = name
+        self.status = status
+        self.members = members
+
+
+class PlatformGroupVariables:
     def __init__(self, id: str, name: str, status: Status = None, members: list[str] = None):
         self.id = id
         self.name = name
@@ -27,12 +39,44 @@ class PlatformOrganizationVariables:
 
 
 class ClientAuthTokenData:
-    def __init__(self, user_id: str, organization_id: str, user_details: PlatformUserVariables = None, organization_details: PlatformOrganizationVariables = None):
+    """
+    https://docs.cord.com/reference/authentication/
+
+    Parameters
+    ----------
+    user_id : str, default None
+        The ID for the user
+    organization_id : str, default None
+        Deprecated, use group_id instead
+    group_id : str, default None
+        The ID for the user’s group
+    user_details : PlatformUserVariables, default None
+        If present, update’s the user’s details, or creates a user with those
+        details if the user_id is new to Cord. This is an object that contains the
+        same fields as the [user management REST endpoint](https://docs.cord.com/rest-apis/users/)
+    organization_details : PlatformOrganizationVariables, default None
+        Deprecated, use group_details instead
+    group_details : PlatformOrganizationVariables, default None
+        If present, updates the group's details, or creates a group
+        with those details if the group_id is new to Cord. This is an object
+        that contains the same fields as the [group management REST endpoint](https://docs.cord.com/rest-apis/groups/)
+
+    """
+    def __init__(self, user_id: str, organization_id: str = None, group_id: str = None, user_details: PlatformUserVariables = None, organization_details: PlatformOrganizationVariables = None,  group_details: PlatformGroupVariables = None):
+
         self.user_id = user_id
         self.organization_id = organization_id
+        if organization_id is not None:
+            warnings.warn("Organization_id is deprecated, use group_id instead", DeprecationWarning)
+        self.group_id = group_id
         self.user_details = user_details
         if self.user_details and self.user_details.id:
             delattr(self.user_details, 'id')
         self.organization_details = organization_details
+        if organization_details is not None:
+            warnings.warn("organization_details is deprecated, use group_details instead", DeprecationWarning)
         if self.organization_details and self.organization_details.id:
             delattr(self.organization_details, 'id')
+        self.group_details = group_details
+        if self.group_details and self.group_details.id:
+            delattr(self.group_details, 'id')

--- a/src/types/types.py
+++ b/src/types/types.py
@@ -72,7 +72,7 @@ class ClientAuthTokenData:
         same fields as the [user management REST endpoint](https://docs.cord.com/rest-apis/users/)
     organization_details : PlatformOrganizationVariables, default None
         Deprecated, use group_details instead
-    group_details : PlatformOrganizationVariables, default None
+    group_details : PlatformGroupVariables, default None
         If present, updates the group's details, or creates a group
         with those details if the group_id is new to Cord. This is an object
         that contains the same fields as the [group management REST endpoint](https://docs.cord.com/rest-apis/groups/)

--- a/src/types/types.py
+++ b/src/types/types.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import json
 import warnings
+from typing import Union, Dict
 
 
 class Status(Enum):
@@ -9,7 +10,30 @@ class Status(Enum):
 
 
 class PlatformUserVariables:
-    def __init__(self, id: str, email: str, name: str = None, short_name: str = None, status: Status = None, profile_picture_url: str = None, metadata: json = {}):
+    """
+    https://docs.cord.com/rest-apis/users/
+
+    Parameters
+    ----------
+    id : str
+        The ID for the user
+    email : str, default None
+        Email address of the user
+    name : str, default None
+        Full user name
+    short_name : str, default None
+        Short user name. In most cases, this will be preferred over name when set.
+    status : Union[str, Literal['active', 'deleted']]
+    profilePictureURL : str, default None
+        This must be a valid URL, which means it needs to follow the usual URL
+        formatting and encoding rules. For example, any space character will need
+        to be encoded as `%20`. We recommend using your programming language's
+        standard URL encoding function, such as `encodeURI` in Javascript.
+    metadata: Dict[str, Union[str, int, bool]] , default None
+        Arbitrary key-value pairs that can be used to store additional information.
+
+    """
+    def __init__(self, id: str, email: str = None, name: str = None, short_name: str = None, status: Status = None, profile_picture_url: str = None, metadata: json = {}):
         self.id = id
         self.email = email
         self.name = name
@@ -18,18 +42,6 @@ class PlatformUserVariables:
         self.profilePictureURL = profile_picture_url
         self.metadata = metadata
 
-
-class PlatformOrganizationVariables:
-    """
-        Deprecated - please use PlatformGroupVariables instead
-    """
-    def __init__(self, id: str, name: str, status: Status = None, members: list[str] = None):
-        self.id = id
-        self.name = name
-        self.status = status
-        self.members = members
-
-
 class PlatformGroupVariables:
     def __init__(self, id: str, name: str, status: Status = None, members: list[str] = None):
         self.id = id
@@ -37,7 +49,11 @@ class PlatformGroupVariables:
         self.status = status
         self.members = members
 
-
+class PlatformOrganizationVariables(PlatformGroupVariables):
+    """
+    Deprecated - please use PlatformGroupVariables instead
+    """
+ 
 class ClientAuthTokenData:
     """
     https://docs.cord.com/reference/authentication/


### PR DESCRIPTION
This diff makes the following changes:
- Deprecated `organization_id` and `organization_details`.
- Replaces `organization_id` with an optional `group_id` and
`organization_details` with `group_details`.
- Updates tests to use the new parameters.
- adds a docstring for the clientAuthTokenData type to provide 
more info on the options.

Test Plan:
Generated a new token with the new parameters and decoded it - contains
the right information
